### PR TITLE
Remove external semver dependency in tests

### DIFF
--- a/test/compress.js
+++ b/test/compress.js
@@ -7,7 +7,7 @@ var child_process = require("child_process");
 var fs = require("fs");
 var path = require("path");
 var sandbox = require("./sandbox");
-var semver = require("semver");
+var semver = require("./semver");
 var U = require("./node");
 
 var batch = 50;

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -2,7 +2,7 @@ var assert = require("assert");
 var exec = require("child_process").exec;
 var fs = require("fs");
 var run_code = require("../sandbox").run_code;
-var semver = require("semver");
+var semver = require("../semver");
 var to_ascii = require("../node").to_ascii;
 
 function read(path) {

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var readFileSync = require("fs").readFileSync;
 var run_code = require("../sandbox").run_code;
-var semver = require("semver");
+var semver = require("../semver");
 var UglifyJS = require("../..");
 
 function read(path) {

--- a/test/mocha/reduce.js
+++ b/test/mocha/reduce.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var fs = require("fs");
 var reduce_test = require("../reduce");
-var semver = require("semver");
+var semver = require("../semver");
 
 function read(path) {
     return fs.readFileSync(path, "utf8");

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var exec = require("child_process").exec;
-var semver = require("semver");
+var semver = require("../semver");
 var UglifyJS = require("../..");
 
 describe("spidermonkey export/import sanity test", function() {

--- a/test/mocha/templates.js
+++ b/test/mocha/templates.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var run_code = require("../sandbox").run_code;
-var semver = require("semver");
+var semver = require("../semver");
 var UglifyJS = require("../node");
 
 describe("Template literals", function() {

--- a/test/sandbox.js
+++ b/test/sandbox.js
@@ -1,5 +1,5 @@
 var readFileSync = require("fs").readFileSync;
-var semver = require("semver");
+var semver = require("./semver");
 var spawnSync = require("child_process").spawnSync;
 var vm = require("vm");
 

--- a/test/semver.js
+++ b/test/semver.js
@@ -1,0 +1,31 @@
+function parse(version) {
+  if (typeof version !== 'string') version = String(version);
+  var m = version.trim().match(/v?(\d+)\.(\d+)\.(\d+)/);
+  if (!m) return [0,0,0];
+  return [parseInt(m[1],10), parseInt(m[2],10), parseInt(m[3],10)];
+}
+
+function compare(a, b) {
+  for (var i = 0; i < 3; i++) {
+    if (a[i] > b[i]) return 1;
+    if (a[i] < b[i]) return -1;
+  }
+  return 0;
+}
+
+exports.satisfies = function(version, range) {
+  var v = parse(version);
+  range = String(range).trim();
+  var m = range.match(/^(<=|>=|<|>|=)?\s*(.*)$/);
+  var op = m[1] || '=';
+  var r = parse(m[2]);
+  var cmp = compare(v, r);
+  switch (op) {
+    case '<': return cmp < 0;
+    case '<=': return cmp <= 0;
+    case '>': return cmp > 0;
+    case '>=': return cmp >= 0;
+    case '=': return cmp === 0;
+    default: return false;
+  }
+};


### PR DESCRIPTION
## Summary
- use a small built-in `semver` helper for tests
- update test files to load local `semver`

## Testing
- `npm test` *(fails: long-running test suite did not finish)*