### PR TITLE
Provide internal semver for tests

### DIFF
--- a/test/compress.js
+++ b/test/compress.js
@@ -7,7 +7,7 @@ var child_process = require("child_process");
 var fs = require("fs");
 var path = require("path");
 var sandbox = require("./sandbox");
-var semver = require("semver");
+var semver = require("./semver");
 var U = require("./node");
 
 var batch = 50;

--- a/test/mocha/cli.js
+++ b/test/mocha/cli.js
@@ -2,7 +2,7 @@ var assert = require("assert");
 var exec = require("child_process").exec;
 var fs = require("fs");
 var run_code = require("../sandbox").run_code;
-var semver = require("semver");
+var semver = require("../semver");
 var to_ascii = require("../node").to_ascii;
 
 function read(path) {

--- a/test/mocha/minify.js
+++ b/test/mocha/minify.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var readFileSync = require("fs").readFileSync;
 var run_code = require("../sandbox").run_code;
-var semver = require("semver");
+var semver = require("../semver");
 var UglifyJS = require("../..");
 
 function read(path) {

--- a/test/mocha/reduce.js
+++ b/test/mocha/reduce.js
@@ -1,7 +1,7 @@
 var assert = require("assert");
 var fs = require("fs");
 var reduce_test = require("../reduce");
-var semver = require("semver");
+var semver = require("../semver");
 
 function read(path) {
     return fs.readFileSync(path, "utf8");

--- a/test/mocha/spidermonkey.js
+++ b/test/mocha/spidermonkey.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var exec = require("child_process").exec;
-var semver = require("semver");
+var semver = require("../semver");
 var UglifyJS = require("../..");
 
 describe("spidermonkey export/import sanity test", function() {

--- a/test/mocha/templates.js
+++ b/test/mocha/templates.js
@@ -1,6 +1,6 @@
 var assert = require("assert");
 var run_code = require("../sandbox").run_code;
-var semver = require("semver");
+var semver = require("../semver");
 var UglifyJS = require("../node");
 
 describe("Template literals", function() {

--- a/test/sandbox.js
+++ b/test/sandbox.js
@@ -1,5 +1,5 @@
 var readFileSync = require("fs").readFileSync;
-var semver = require("semver");
+var semver = require("./semver");
 var spawnSync = require("child_process").spawnSync;
 var vm = require("vm");
 

--- a/test/semver.js
+++ b/test/semver.js
@@ -1,0 +1,32 @@
+function parse(v) {
+  if (typeof v !== 'string') return {major:0, minor:0, patch:0};
+  if (v[0] === 'v' || v[0] === 'V') v = v.slice(1);
+  var parts = v.split('.');
+  return {
+    major: parseInt(parts[0], 10) || 0,
+    minor: parseInt(parts[1], 10) || 0,
+    patch: parseInt(parts[2], 10) || 0
+  };
+}
+function cmp(a, b) {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+function satisfies(version, range) {
+  var v = parse(version);
+  var m = /^([<>]=?|=)?\s*(\d+)(?:\.(\d+))?/.exec(range.trim());
+  if (!m) throw new Error('Unsupported range: ' + range);
+  var op = m[1] || '=';
+  var r = {major:+m[2], minor:m[3]?+m[3]:0, patch:0};
+  var c = cmp(v, r);
+  switch(op) {
+    case '<': return c < 0;
+    case '<=': return c <= 0;
+    case '>': return c > 0;
+    case '>=': return c >= 0;
+    case '=': return c === 0;
+    default: throw new Error('Unsupported operator: ' + op);
+  }
+}
+module.exports = { satisfies };


### PR DESCRIPTION
## Summary
- implement a small `semver` helper used by the test suite
- update tests to reference the local helper

## Testing
- `node -e "const semver=require('./test/semver'); console.log(semver.satisfies('v22.15.0','>=8'));"`
- `node test/compress.js` *(fails: killed after many tests)*